### PR TITLE
Améliorations diverses demandées par Rox en 2025

### DIFF
--- a/app/Filament/Admin/Resources/ClassementResource.php
+++ b/app/Filament/Admin/Resources/ClassementResource.php
@@ -68,6 +68,9 @@ class ClassementResource extends Resource
                     ->label('Points')
                     ->sortable()
                 ])
+            ->modifyQueryUsing(function (Builder $query) {
+                $query->where('role', '!=', 'none');
+            })
             ->filters([
                 //
             ])

--- a/app/Filament/Admin/Resources/MembersResource.php
+++ b/app/Filament/Admin/Resources/MembersResource.php
@@ -10,6 +10,8 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Filament\Tables\Filters\Filter;
+use Illuminate\Database\Eloquent\Builder;
 
 class MembersResource extends Resource
 {
@@ -53,14 +55,19 @@ class MembersResource extends Resource
                     )
                 ]
             )
-            ->filters(
-                [
+            ->filters([
                 Tables\Filters\SelectFilter::make('role')
                     ->options(enum_pluck(MemberRole::class))
                     ->label('Rôle')
-                    ->placeholder('Tous les rôles')
-                ]
-            )
+                    ->placeholder('Tous les rôles'),
+                Filter::make('Pic actuel')
+                    ->label('Pic actuel')
+                    ->toggle()
+                    ->default()
+                    ->query(function (Builder $query) {
+                        $query->where('role', '!=', 'none');
+                    }),
+            ])
             ->actions(
                 [
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Admin/Widgets/NoteAstreinteOverview.php
+++ b/app/Filament/Admin/Widgets/NoteAstreinteOverview.php
@@ -49,7 +49,7 @@ class NoteAstreinteOverview extends BaseWidget
             ->join('creneau', 'astreintes.creneau_id', '=', 'creneau.id')
             ->whereBetween('date', [self::getStartSemester(), self::getEndSemester()])
             ->count();
-        $totalUsers = User::query()->where("role", "admin")->count();
+        $totalUsers = User::query()->where("role", "!=", "none")->count();
         $averageAstreintesPerUser = $totalUsers > 0 ? $totalAstreintes / $totalUsers : 0;
 
         // Somme des astreintes pour les types "Matin 1" et "Matin 2"

--- a/app/Filament/Treso/Pages/AnalyseFactures.php
+++ b/app/Filament/Treso/Pages/AnalyseFactures.php
@@ -2,22 +2,24 @@
 
 namespace App\Filament\Treso\Pages;
 
+use App\Models\CategorieFacture;
 use App\Models\MontantCategorie;
 use App\Models\FactureRecue;
-use Carbon\Carbon;
+use App\Models\Recettes;
 use Filament\Pages\Page;
 use Filament\Forms\Components\DatePicker;
 
 class AnalyseFactures extends Page
 {
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar';
-    protected static ?string $title = 'Analyse des Factures Reçues';
+    protected static ?string $title = 'Analyse Générale';
     protected static string $view = 'filament.treso.pages.analyse-factures';
 
     public $date_debut;
     public $date_fin;
-    public $total = 0;
     public $totalsByCategory = [];
+    public $totalRecettes = 0;
+    public $totalDepenses = 0;
 
     protected function getFormSchema(): array
     {
@@ -33,18 +35,51 @@ class AnalyseFactures extends Page
 
     public function calculerTotal()
     {
-        $this->total = FactureRecue::whereBetween('date', [$this->date_debut, $this->date_fin])
+        $this->totalDepenses = FactureRecue::whereBetween('date', [$this->date_debut, $this->date_fin])
             ->sum('prix');
+
+        $this->totalRecettes = Recettes::whereBetween('date_fin', [$this->date_debut, $this->date_fin])  // On se base sur la date de fin de la recette pour savoir si on la prend en compte ou pas
+            ->sum('valeur');
     }
 
-    public function calculerTotals()
+    public function calculerTotaux()
     {
-        $this->totalsByCategory = MontantCategorie::with('categorie')
+        $recettesByCategory = CategorieFacture::with(['recettes' => function ($query) {  // Calcule les recettes par catégorie
+                $query->whereBetween('date_debut', [$this->date_debut, $this->date_fin]);
+            }])
+            ->get()
+            ->mapWithKeys(function ($categorie) {
+                $totalRecettes = $categorie->recettes->sum('valeur');
+                return [
+                    $categorie->id => [
+                        'categorie' => $categorie->nom,
+                        'totalRecettes' => $totalRecettes,
+                        'totalDepenses' => 0, // On init pour l'instant à 0, le calcul est fait apr.
+                    ],
+                ];
+            })
+            ->toArray(); // Convertir en tableau
+
+        $depensesByCategory = MontantCategorie::with('categorie')   // calcule maintenant les dépenses (factures reçues) par catégories
             ->whereHas('facture', function ($query) {
                 $query->whereBetween('date', [$this->date_debut, $this->date_fin]);
             })
             ->selectRaw('categorie_id, SUM(prix) as total_prix')
             ->groupBy('categorie_id')
             ->get();
+
+        foreach ($depensesByCategory as $depense) {    // fusionner les res dans un array
+            if (isset($recettesByCategory[$depense->categorie_id])) {
+                $recettesByCategory[$depense->categorie_id]['totalDepenses'] = $depense->total_prix;
+            } else {
+                $recettesByCategory[$depense->categorie_id] = [
+                    'categorie' => $depense->categorie->nom,
+                    'totalRecettes' => 0,
+                    'totalDepenses' => $depense->total_prix,
+                ];
+            }
+        }
+
+        $this->totalsByCategory = array_values($recettesByCategory);
     }
 }

--- a/app/Filament/Treso/Pages/AnalyseFactures.php
+++ b/app/Filament/Treso/Pages/AnalyseFactures.php
@@ -9,6 +9,7 @@ use App\Models\Recettes;
 use Filament\Pages\Page;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Grid;
 
 class AnalyseFactures extends Page
 {
@@ -27,30 +28,39 @@ class AnalyseFactures extends Page
     protected function getFormSchema(): array
     {
         return [
-            DatePicker::make('date_debut')
-                ->label('Date de début')
-                ->required(),
-            DatePicker::make('date_fin')
-                ->label('Date de fin')
-                ->required(),
-            Select::make('date_facture')
-                ->label('Date pour la facture')
-                ->options([
-                    'date' => 'Date de facturation',
-                    'date_paiement' => 'Date de paiement',
-                    'date_remboursement' => 'Date de remboursement',
-                ])
-                ->required(),
-            
-            Select::make('date_recette')
-                ->label('Date pour la recette')
-                ->options([
-                    'date_debut' => 'Date de début',
-                    'date_fin' => 'Date de fin',
-                ])
-                ->required(),            
+            Grid::make()
+                ->schema([
+                    DatePicker::make('date_debut')
+                        ->label('Date de début')
+                        ->required()
+                        ->columnSpan(1),
+    
+                    DatePicker::make('date_fin')
+                        ->label('Date de fin')
+                        ->required()
+                        ->columnSpan(1),
+    
+                    Select::make('date_facture')
+                        ->label('Date pour la facture')
+                        ->options([
+                            'date' => 'Date de facturation',
+                            'date_paiement' => 'Date de paiement',
+                            'date_remboursement' => 'Date de remboursement',
+                        ])
+                        ->required()
+                        ->columnSpan(1), 
+    
+                    Select::make('date_recette')
+                        ->label('Date pour la recette')
+                        ->options([
+                            'date_debut' => 'Date de début',
+                            'date_fin' => 'Date de fin',
+                        ])
+                        ->required()
+                        ->columnSpan(1),
+                ]),
         ];
-    }
+    }    
 
     public function calculerTotal()
     {

--- a/app/Filament/Treso/Resources/FactureRecueResource.php
+++ b/app/Filament/Treso/Resources/FactureRecueResource.php
@@ -59,7 +59,7 @@ class FactureRecueResource extends Resource
                     ->numeric()
                     ->suffixIcon('heroicon-o-currency-euro'),
                 TextInput::make('tva')
-                    ->label('TVA (€)')
+                    ->label('Total TVA(€)')
                     ->required()
                     ->numeric()
                     ->suffixIcon('heroicon-o-currency-euro'),
@@ -117,12 +117,17 @@ class FactureRecueResource extends Resource
                             ->searchable()
                             ->required()
                             ->distinct()
-                            ->columnSpan(3),
+                            ->columnSpan(2),
                         TextInput::make('prix')
                             ->label('Montant de la catégorie')
                             ->numeric()
                             ->suffixIcon('heroicon-o-currency-euro')
-                            ->columnSpan(3),
+                            ->columnSpan(2),
+                        TextInput::make('tva')
+                            ->label('TVA')
+                            ->numeric()
+                            ->suffixIcon('heroicon-o-currency-euro')
+                            ->columnSpan(2),
                         ]
                     )
                     ->defaultItems(1)

--- a/app/Filament/Treso/Resources/FactureRecueResource.php
+++ b/app/Filament/Treso/Resources/FactureRecueResource.php
@@ -68,6 +68,7 @@ class FactureRecueResource extends Resource
                     ->required()
                     ->maxLength(255),
                 DatePicker::make('date')
+                    ->label('Date Facturation')
                     ->required()
                     ->timezone('Europe/Paris'),
                 DatePicker::make('date_paiement')
@@ -154,6 +155,7 @@ class FactureRecueResource extends Resource
                 TextColumn::make('destinataire')
                      ->searchable(),
                 TextColumn::make('date')
+                    ->label('Date Facturation')
                     ->date('M d, Y')
                     ->searchable(),
                 TextColumn::make('date_paiement')

--- a/app/Filament/Treso/Resources/FactureRecueResource.php
+++ b/app/Filament/Treso/Resources/FactureRecueResource.php
@@ -6,6 +6,7 @@ use App\Filament\Treso\Resources\FactureRecueResource\Pages;
 use App\Models\CategorieFacture;
 use App\Models\FactureRecue;
 use App\Models\Semestre;
+use Closure;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
@@ -57,12 +58,29 @@ class FactureRecueResource extends Resource
                     ->label('Prix Total TTC (€)')
                     ->required()
                     ->numeric()
-                    ->suffixIcon('heroicon-o-currency-euro'),
+                    ->suffixIcon('heroicon-o-currency-euro')
+                    ->rule(function ($get) {
+                        return function (string $attribute, $value, Closure $fail) use ($get) {
+                            $totalCategoriesPrix = array_sum(array_column($get('categoriePrix') ?? [], 'prix'));
+                            if ($value != $totalCategoriesPrix) {
+                                $fail('Le prix total doit correspondre à la somme des montants des catégories.');
+                            }
+                        };
+                    }),
+                
                 TextInput::make('tva')
-                    ->label('Total TVA(€)')
+                    ->label('Total TVA (€)')
                     ->required()
                     ->numeric()
-                    ->suffixIcon('heroicon-o-currency-euro'),
+                    ->suffixIcon('heroicon-o-currency-euro')
+                    ->rule(function ($get) {
+                        return function (string $attribute, $value, Closure $fail) use ($get) {
+                            $totalCategoriesTVA = array_sum(array_column($get('categoriePrix') ?? [], 'tva'));
+                            if ($value != $totalCategoriesTVA) {
+                                $fail('Le total de la TVA doit correspondre à la somme des TVA des catégories.');
+                            }
+                        };
+                    }),                
                 TextInput::make('moyen_paiement')
                     //->label
                     ->required()

--- a/app/Filament/Treso/Resources/RecetteResource.php
+++ b/app/Filament/Treso/Resources/RecetteResource.php
@@ -36,7 +36,18 @@ class RecetteResource extends Resource
                     ->searchable()
                     ->required()
                     ->distinct()
-                    ->columnSpan(3),
+                    ->columnSpan(2),
+                TextInput::make('valeur')
+                    ->label('Valeur TTC')
+                    ->required()
+                    ->numeric()
+                    ->suffixIcon('heroicon-o-currency-euro')
+                    ->columnSpan(2),
+                TextInput::make('tva')
+                    ->label('TVA (€)')
+                    ->numeric()
+                    ->suffixIcon('heroicon-o-currency-euro')
+                    ->columnSpan(2),
                 DatePicker::make('date_debut')
                     ->label('Date début')
                     ->required()
@@ -48,18 +59,8 @@ class RecetteResource extends Resource
                     ->date()
                     ->columnSpan(2)
                     ->timezone('Europe/Paris'),
-                TextInput::make('valeur')
-                    ->label('Valeur TTC')
-                    ->required()
-                    ->numeric()
-                    ->suffixIcon('heroicon-o-currency-euro'),
-                TextInput::make('tva')
-                    ->label('TVA (€)')
-                    ->numeric()
-                    ->suffixIcon('heroicon-o-currency-euro')
-                    ->columnSpan(3),
                 TextInput::make('remarque')
-                    ->columnSpan(3)
+                    ->columnSpan(6)
                     ->required()
                     ->maxLength(255),
                 Select::make('semestre_id')

--- a/app/Filament/Treso/Resources/RecetteResource.php
+++ b/app/Filament/Treso/Resources/RecetteResource.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Filament\Treso\Resources;
+
+use App\Filament\Treso\Resources\RecetteResource\Pages;
+use App\Models\Recettes;
+use App\Models\Semestre;
+use App\Models\CategorieFacture;
+use Filament\Forms\Components\DatePicker;
+use Filament\Notifications\Notification;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class RecetteResource extends Resource
+{
+    protected static ?string $model = Recettes::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-currency-euro';
+
+    protected static ?string $navigationGroup = 'Factures';
+
+
+    public static function form(Form $form): Form
+    {
+        $semestreActif = Semestre::where('activated', true)->first();
+        return $form
+            ->schema([
+                Select::make('categorie_id')
+                    ->label('Catégorie')
+                    ->options(CategorieFacture::query()->pluck('nom', 'id'))
+                    ->searchable()
+                    ->required()
+                    ->distinct()
+                    ->columnSpan(3),
+                DatePicker::make('date_debut')
+                    ->label('Date début')
+                    ->required()
+                    ->date()
+                    ->columnSpan(2)
+                    ->timezone('Europe/Paris'),
+                DatePicker::make('date_fin')
+                    ->label('Date fin')
+                    ->date()
+                    ->columnSpan(2)
+                    ->timezone('Europe/Paris'),
+                TextInput::make('valeur')
+                    ->label('Valeur TTC')
+                    ->required()
+                    ->numeric()
+                    ->suffixIcon('heroicon-o-currency-euro'),
+                TextInput::make('tva')
+                    ->label('TVA (€)')
+                    ->numeric()
+                    ->suffixIcon('heroicon-o-currency-euro')
+                    ->columnSpan(3),
+                TextInput::make('remarque')
+                    ->columnSpan(3)
+                    ->required()
+                    ->maxLength(255),
+                Select::make('semestre_id')
+                    ->label('Semestre')
+                    ->options(Semestre::all()->pluck('state', 'id'))
+                    ->searchable()
+                    ->default($semestreActif->id)
+                    ->required()
+                    ->columnSpan(6),
+            ])->columns(6);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('categorie_id')
+                    ->label('Catégorie')
+                    ->formatStateUsing(
+                        function ($state) {
+                            return CategorieFacture::find($state)->nom;
+                        }
+                    ),
+                TextColumn::make('date_debut')
+                    ->date('M d, Y'),
+                TextColumn::make('date_fin')
+                    ->date('M d, Y'),
+                TextColumn::make('valeur')
+                    ->label('Valeur TTC')
+                    ->formatStateUsing(fn (string $state): string => __(number_format($state, 2) . " €")),
+                TextColumn::make('tva')
+                    ->label('TVA')
+                    ->formatStateUsing(fn (string $state): string => __(number_format($state, 2) . " €")),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('semestre_id')
+                        ->options(Semestre::all()->pluck('state', 'id'))
+                        ->label('Semestre')
+                        ->placeholder('Tous les semestre')
+                ]
+            )
+            ->actions([
+                Tables\Actions\Action::make('voir_remarque')
+                    ->label('Voir Remarque')
+                    ->icon('heroicon-o-eye')
+                    ->visible(fn (Recettes $record) => !is_null($record->remarque))
+                    ->action(function (Recettes $record, $data) {
+                        Notification::make()
+                            ->title('Commentaire')
+                            ->body($record->commentaire)
+                            ->info()
+                            ->send();
+                    }),
+                Tables\Actions\EditAction::make(),
+                tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListRecette::route('/'),
+            'create' => Pages\CreateRecette::route('/create'),
+            'edit' => Pages\EditRecette::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Treso/Resources/RecetteResource/Pages/CreateRecette.php
+++ b/app/Filament/Treso/Resources/RecetteResource/Pages/CreateRecette.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Treso\Resources\RecetteResource\Pages;
+
+use App\Filament\Treso\Resources\RecetteResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRecette extends CreateRecord
+{
+    protected static string $resource = RecetteResource::class;
+}

--- a/app/Filament/Treso/Resources/RecetteResource/Pages/EditRecette.php
+++ b/app/Filament/Treso/Resources/RecetteResource/Pages/EditRecette.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Treso\Resources\RecetteResource\Pages;
+
+use App\Filament\Treso\Resources\RecetteResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRecette extends EditRecord
+{
+    protected static string $resource = RecetteResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Treso/Resources/RecetteResource/Pages/ListRecette.php
+++ b/app/Filament/Treso/Resources/RecetteResource/Pages/ListRecette.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Treso\Resources\RecetteResource\Pages;
+
+use App\Filament\Treso\Resources\RecetteResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRecette extends ListRecords
+{
+    protected static string $resource = RecetteResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/CategorieFacture.php
+++ b/app/Models/CategorieFacture.php
@@ -22,6 +22,11 @@ class CategorieFacture extends Model
         return $this->nom;
     }
 
+    public function recettes()
+    {
+        return $this->hasMany(Recettes::class, 'categorie_id');
+    }
+
     public function children()
     {
         return $this->hasMany(CategorieFacture::class, 'id_parent');

--- a/app/Models/MontantCategorie.php
+++ b/app/Models/MontantCategorie.php
@@ -10,7 +10,7 @@ class MontantCategorie extends Model
     use HasFactory;
 
     protected $table = 'montant_categorie';
-    protected $fillable = ['categorie_id', 'prix', 'facture_id'];
+    protected $fillable = ['categorie_id', 'prix', 'tva', 'facture_id'];
 
     // Ajoutez une relation avec CategorieFactureRecue
     public function categorie()

--- a/app/Models/Recettes.php
+++ b/app/Models/Recettes.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Recettes extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'categorie_id','date_debut','date_fin','valeur','tva','remarque','semestre_id'
+    ];
+
+    public function categorie()
+    {
+        return $this->belongsTo(CategorieFacture::class, 'categorie_id');
+    }
+
+    public function semestre()
+    {
+        return $this->belongsTo(Semestre::class, 'semestre_id');
+    }
+
+    public function getPriceWithoutTaxes()
+    {
+        return round($this->valeur * (100 / (100 + $this->tva)), 2);
+    }
+    
+    public function getTotalTaxes()
+    {
+        return round($this->valeur - $this->getPriceWithoutTaxes(), 2);
+    }
+}

--- a/database/migrations/2023_11_29_140038_create_categorie_prix_table.php
+++ b/database/migrations/2023_11_29_140038_create_categorie_prix_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
         Schema::create('montant_categorie', function (Blueprint $table) {
             $table->id();
             $table->float('prix')->default(0);
+            $table->float('tva')->default(0);
             $table->foreignId('categorie_id')->constrained('categorie_factures')->onDelete('cascade');
             $table->foreignId('facture_id')->constrained('facture_recues')->onDelete('cascade');
             $table->timestamps();

--- a/database/migrations/2025_02_20_151840_create_recettes_table.php
+++ b/database/migrations/2025_02_20_151840_create_recettes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('recettes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('categorie_id')->constrained('categorie_factures');
+            $table->date('date_debut');
+            $table->date('date_fin');
+            $table->float('valeur')->default(0);
+            $table->float('tva')->default(0);
+            $table->text('remarque')->nullable();
+            $table->foreignId('semestre_id')->constrained();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('recettes');
+    }
+};

--- a/resources/views/filament/treso/pages/analyse-factures.blade.php
+++ b/resources/views/filament/treso/pages/analyse-factures.blade.php
@@ -18,7 +18,7 @@
     @endif
 
     <!-- Bouton pour calculer le total par catégorie -->
-    <button wire:click="calculerTotaux" style="margin: 15px; padding: 8px; background-color: #1e40af" class="fi-btn relative grid-flow-col items-center justify-center font-semibold outline-none transition duration-75 focus-visible:ring-2 rounded-lg fi-color-custom fi-btn-color-primary fi-size-md fi-btn-size-md gap-1.5 px-3 py-2 text-sm inline-grid shadow-sm bg-custom-600 text-white hover:bg-custom-500 dark:bg-custom-500 dark:hover:bg-custom-400 focus-visible:ring-custom-500/50 dark:focus-visible:ring-custom-400/50 fi-ac-btn-action">
+    <button wire:click="calculerTotaux" style="margin: 35px; padding: 8px; background-color: #1e40af" class="fi-btn relative grid-flow-col items-center justify-center font-semibold outline-none transition duration-75 focus-visible:ring-2 rounded-lg fi-color-custom fi-btn-color-primary fi-size-md fi-btn-size-md gap-1.5 px-3 py-2 text-sm inline-grid shadow-sm bg-custom-600 text-white hover:bg-custom-500 dark:bg-custom-500 dark:hover:bg-custom-400 focus-visible:ring-custom-500/50 dark:focus-visible:ring-custom-400/50 fi-ac-btn-action">
         Calculer Total par Catégorie
     </button>
 

--- a/resources/views/filament/treso/pages/analyse-factures.blade.php
+++ b/resources/views/filament/treso/pages/analyse-factures.blade.php
@@ -13,8 +13,7 @@
     @if ($totalRecettes !== null || $totalDepenses !== null)
         <div class="p-8 bg-center shadow rounded">
             <h2 class="text-lg font-semibold">Totaux entre les dates sélectionnées :</h2>
-            <p class="text-2xl font-bold my-8">Recettes : {{ number_format($totalRecettes, 2) }} € | Dépenses : {{ number_format($totalDepenses, 2) }} €</p>
-            <p class="text-m italic">* Les calculs se réfèrent à la date de fin des recettes</p>
+            <p class="text-2xl font-bold">Recettes : {{ number_format($totalRecettes, 2) }} € | Dépenses : {{ number_format($totalDepenses, 2) }} €</p>
         </div>
     @endif
 

--- a/resources/views/filament/treso/pages/analyse-factures.blade.php
+++ b/resources/views/filament/treso/pages/analyse-factures.blade.php
@@ -11,9 +11,10 @@
 
     <!-- Affichage des totaux globaux -->
     @if ($totalRecettes !== null || $totalDepenses !== null)
-        <div class="p-4 bg-center shadow rounded">
+        <div class="p-8 bg-center shadow rounded">
             <h2 class="text-lg font-semibold">Totaux entre les dates sélectionnées :</h2>
-            <p class="text-2xl font-bold">Recettes : {{ number_format($totalRecettes, 2) }} € | Dépenses : {{ number_format($totalDepenses, 2) }} €</p>
+            <p class="text-2xl font-bold my-8">Recettes : {{ number_format($totalRecettes, 2) }} € | Dépenses : {{ number_format($totalDepenses, 2) }} €</p>
+            <p class="text-m italic">* Les calculs se réfèrent à la date de fin des recettes</p>
         </div>
     @endif
 
@@ -29,9 +30,11 @@
             <table style="border-radius: 5px" class="w-full roun border border-white mt-2">
                 <thead>
                 <tr>
-                    <th class="px-4 py-2 border-b w-1/3">Catégorie</th>
+                    <th class="px-4 py-2 border-b w-1/3">Catégories</th>
                     <th style="background-color: #FF7F7F; color:black;" class="px-4 py-2 border-b w-1/3">Dépenses</th>
+                    <th style="background-color: #FF7F7F; color:black;" class="px-4 py-2 border-b w-1/3">TVA</th>
                     <th style="background-color: #89E894; color:black;" class="px-4 py-2 border-b w-1/3">Recettes</th>
+                    <th style="background-color: #89E894; color:black;" class="px-4 py-2 border-b w-1/3">TVA</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -39,7 +42,9 @@
                     <tr>
                         <td class="px-4 py-2 border-b text-center">{{ $total['categorie'] }}</td>
                         <td style="background-color: #FF7F7F; color:black;" class="px-4 py-2 border-b text-center">{{ number_format($total['totalDepenses'], 2) }} €</td>
+                        <td style="background-color: #FF7F7F; color:black;" class="px-4 py-2 border-b text-center">{{ number_format($total['totalTvaDepenses'], 2) }} €</td>
                         <td style="background-color: #89E894; color:black;" class="px-4 py-2 border-b text-center">{{ number_format($total['totalRecettes'], 2) }} €</td>
+                        <td style="background-color: #89E894; color:black;" class="px-4 py-2 border-b text-center">{{ number_format($total['totalTvaRecettes'], 2) }} €</td>
                     </tr>
                 @endforeach
                 </tbody>

--- a/resources/views/filament/treso/pages/analyse-factures.blade.php
+++ b/resources/views/filament/treso/pages/analyse-factures.blade.php
@@ -5,21 +5,20 @@
         <div style="display: flex; justify-content: center">
             <button style="margin: 15px; padding: 8px; background-color: #1e40af" class="fi-btn relative grid-flow-col items-center justify-center font-semibold outline-none transition duration-75 focus-visible:ring-2 rounded-lg fi-color-custom fi-btn-color-primary fi-size-md fi-btn-size-md gap-1.5 px-3 py-2 text-sm inline-grid shadow-sm bg-custom-600 text-white hover:bg-custom-500 dark:bg-custom-500 dark:hover:bg-custom-400 focus-visible:ring-custom-500/50 dark:focus-visible:ring-custom-400/50 fi-ac-btn-action">
                 Calculer Total Global
-            </button></div>
-        <!-- Bouton pour calculer le total global -->
-
+            </button>
+        </div>
     </form>
 
-    <!-- Affichage du total global -->
-    @if ($total !== null)
-        <div class="mt-6 p-4 bg-center shadow rounded">
-            <h2 class="text-lg font-semibold">Total des factures entre les dates sélectionnées :</h2>
-            <p class="text-2xl font-bold">{{ number_format($total, 2) }} €</p>
+    <!-- Affichage des totaux globaux -->
+    @if ($totalRecettes !== null || $totalDepenses !== null)
+        <div class="p-4 bg-center shadow rounded">
+            <h2 class="text-lg font-semibold">Totaux entre les dates sélectionnées :</h2>
+            <p class="text-2xl font-bold">Recettes : {{ number_format($totalRecettes, 2) }} € | Dépenses : {{ number_format($totalDepenses, 2) }} €</p>
         </div>
     @endif
 
     <!-- Bouton pour calculer le total par catégorie -->
-    <button wire:click="calculerTotals" style="margin: 15px; padding: 8px; background-color: #1e40af" class="fi-btn relative grid-flow-col items-center justify-center font-semibold outline-none transition duration-75 focus-visible:ring-2 rounded-lg fi-color-custom fi-btn-color-primary fi-size-md fi-btn-size-md gap-1.5 px-3 py-2 text-sm inline-grid shadow-sm bg-custom-600 text-white hover:bg-custom-500 dark:bg-custom-500 dark:hover:bg-custom-400 focus-visible:ring-custom-500/50 dark:focus-visible:ring-custom-400/50 fi-ac-btn-action">
+    <button wire:click="calculerTotaux" style="margin: 15px; padding: 8px; background-color: #1e40af" class="fi-btn relative grid-flow-col items-center justify-center font-semibold outline-none transition duration-75 focus-visible:ring-2 rounded-lg fi-color-custom fi-btn-color-primary fi-size-md fi-btn-size-md gap-1.5 px-3 py-2 text-sm inline-grid shadow-sm bg-custom-600 text-white hover:bg-custom-500 dark:bg-custom-500 dark:hover:bg-custom-400 focus-visible:ring-custom-500/50 dark:focus-visible:ring-custom-400/50 fi-ac-btn-action">
         Calculer Total par Catégorie
     </button>
 
@@ -27,18 +26,20 @@
     @if ($totalsByCategory)
         <div class="mt-6">
             <h3 class="text-lg font-semibold">Total par catégorie</h3>
-            <table style="border-radius: 5px" class="w-full roun border border-gray-200 mt-2">
+            <table style="border-radius: 5px" class="w-full roun border border-white mt-2">
                 <thead>
                 <tr>
-                    <th style="background-color: #008855;" class="px-4 py-2 border-b w-1/2">Catégorie</th>
-                    <th style="background-color: #008855;" class="px-4 py-2 border-b w-1/2">Total</th>
+                    <th class="px-4 py-2 border-b w-1/3">Catégorie</th>
+                    <th style="background-color: #FF7F7F; color:black;" class="px-4 py-2 border-b w-1/3">Dépenses</th>
+                    <th style="background-color: #89E894; color:black;" class="px-4 py-2 border-b w-1/3">Recettes</th>
                 </tr>
                 </thead>
                 <tbody>
                 @foreach ($totalsByCategory as $total)
                     <tr>
-                        <td style="background-color: #119e69;" class="px-4 py-2 border-b text-center">{{ $total->categorie->nom }}</td>
-                        <td style="background-color: #119e69;" class="px-4 py-2 border-b text-center">{{ number_format($total->total_prix, 2) }} €</td>
+                        <td class="px-4 py-2 border-b text-center">{{ $total['categorie'] }}</td>
+                        <td style="background-color: #FF7F7F; color:black;" class="px-4 py-2 border-b text-center">{{ number_format($total['totalDepenses'], 2) }} €</td>
+                        <td style="background-color: #89E894; color:black;" class="px-4 py-2 border-b text-center">{{ number_format($total['totalRecettes'], 2) }} €</td>
                     </tr>
                 @endforeach
                 </tbody>
@@ -56,12 +57,9 @@
         }
 
         th, td {
-            border: 1px solid #ccc; /* Bordures internes des cellules */
+            border: 1px solid #ffffff; /* Bordures internes des cellules */
             padding: 10px; /* Ajoute de l'espace interne */
             text-align: center; /* Centre le contenu */
         }
-
     </style>
 </x-filament::page>
-
-


### PR DESCRIPTION
- Créer une catégorie pour les attestations de vente (pour les achats où on peut pas avoir de factures : emmaüs, le bon coin etc.) et les prendre en compte dans la fonctionnalité analyse des factures (pour pouvoir savoir vraiment où on en est niveau dépenses)
- Ajouter une fonctionnalité pour qu'on puisse analyser les factures soit en fonction de la date de paiement / remboursement ou alors de la date de facturation (actuellement c'est juste en fonction de la date de facturation)
- Pour l'analyse des factures afficher le total de tva (comme pour le total des dépenses)
- Quand on ajoute une facture, ajouter une vérification lorsqu'on ajoute les dépenses en fonction des catégories pour pas qu'on fasse d'erreurs (parce que pour une facture il peut y avoir des dépenses qui correspondent à différentes catégorie, genre déco, anim et tout) : comparer la somme des différentes catégories avec le montant total de la facture, oui on peut le faire à la main mais si ça peut être automatisé c'est banger. Si ya une erreur, juste mettre un msg d'alerte 
- Ajouter un truc sur picsous pour qu'on puisse ajouter à la main les recettes weezpay (histoire de tout centraliser) et après faire les totaux